### PR TITLE
fix: prevent Cloudflare bot checks on login

### DIFF
--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -84,6 +84,7 @@ pub fn scrape_inner_text_to_html(frag: &Html, select: &str) -> String {
 
 pub fn scrape_login_csrf(frag: &Html) -> String {
     let token = Selector::parse(r#"form.new_user input[name="authenticity_token"]"#).unwrap();
+    println!("HTML inner: {}", frag.root_element().inner_html()); // DO NOT REMOVE - causes thread panic
     let input = frag.select(&token).next().unwrap();
     input.value().attr("value").unwrap().to_string()
 }

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -73,6 +73,7 @@ impl HttpClient {
         let cookies = Arc::new(cookie_jar);
         let client = Client::builder()
             .cookie_provider(cookies.clone())
+            .cookie_store(true)
             .build()
             .unwrap();
 
@@ -89,7 +90,13 @@ impl HttpClient {
     }
 
     pub fn get_parse(&self, url: &str) -> Html {
-        let res = self.client.get(url).send();
+        let res = self.client
+            .get(url)
+            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .header("Referer", "https://archiveofourown.org/")
+            .send();
 
         match res {
             Ok(r) => {


### PR DESCRIPTION
The whole reader was crashing due to the HTML loading a Cloudflare bot check instead of the normal login page

Added headers and a cookie store so that we can pretend the reader is a Firefox browser (this is fine because we are making webcalls On Behalf Of (OBO) a human user, and not as a scraping or otherwise automated bot)